### PR TITLE
Remove box-sizing rule to prevent spacing conflicts with cf.gov

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,11 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
-html {
+#ctrl-f-modal {
   box-sizing: border-box;
 }
-*,
-*:before,
-*:after {
+
+#ctrl-f-modal *,
+#ctrl-f-modal *:before,
+#ctrl-f-modal *:after {
   box-sizing: inherit;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,12 +1,3 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-html {
-  box-sizing: border-box;
-}
-*,
-*:before,
-*:after {
-  box-sizing: inherit;
-}


### PR DESCRIPTION
In https://github.com/cfpb/consumerfinance.gov/pull/7754, noted that this box-sizing rule breaks our standard cf.gov layout. It doesn't appear to be load-bearing, so I removed it.

Testing:
 - Pull and build
 - Things should appear unbroken ^_^